### PR TITLE
Fix "Close on launch" for non-Windows platforms

### DIFF
--- a/configure
+++ b/configure
@@ -2822,20 +2822,6 @@ fi
 { $as_echo "$as_me:${as_lineno-$LINENO}: result: yes" >&5
 $as_echo "yes" >&6; }
 
-{ $as_echo "$as_me:${as_lineno-$LINENO}: checking setting project options" >&5
-$as_echo_n "checking setting project options... " >&6; }
-bnv_try_15="echo \"QT += network\" >> qzdl.pro"
-{ { eval echo "\"\$as_me\":${as_lineno-$LINENO}: \"$bnv_try_15\""; } >&5
-  (eval $bnv_try_15) 2>&5
-  ac_status=$?
-  $as_echo "$as_me:${as_lineno-$LINENO}: \$? = $ac_status" >&5
-  test $ac_status = 0; }
-if test "$ac_status" != 0; then
-   as_fn_error $? "error appending to file" "$LINENO" 5
-fi
-{ $as_echo "$as_me:${as_lineno-$LINENO}: result: yes" >&5
-$as_echo "yes" >&6; }
-
 { $as_echo "$as_me:${as_lineno-$LINENO}: checking enabling debug" >&5
 $as_echo_n "checking enabling debug... " >&6; }
 bnv_try_15="echo \"CONFIG += debug\" >> qzdl.pro"

--- a/configure.in
+++ b/configure.in
@@ -11,14 +11,6 @@ if test "$ac_status" != 0; then
 fi
 AC_MSG_RESULT(yes)
 
-AC_MSG_CHECKING(setting project options)
-bnv_try_15="echo \"QT += network\" >> qzdl.pro"
-AC_TRY_EVAL(bnv_try_15)
-if test "$ac_status" != 0; then
-   AC_MSG_ERROR(error appending to file)
-fi
-AC_MSG_RESULT(yes)
-
 AC_MSG_CHECKING(enabling debug)
 bnv_try_15="echo \"CONFIG += debug\" >> qzdl.pro"
 AC_TRY_EVAL(bnv_try_15)

--- a/src/ZDLMainWindow.cpp
+++ b/src/ZDLMainWindow.cpp
@@ -340,7 +340,13 @@ void ZDLMainWindow::launch(){
 	proc->setWorkingDirectory(workingDirectory);
 
 	proc->setProcessChannelMode(QProcess::ForwardedChannels);
-	proc->start(exec, args);
+
+	if (zconf->hasValue("zdl.general", "autoclose")) {
+		proc->startDetached(exec, args);
+	} else {
+		proc->start(exec, args);
+	}
+
 	procerr = proc->error();
 #endif
 	int stat;

--- a/src/ZDLMainWindow.cpp
+++ b/src/ZDLMainWindow.cpp
@@ -340,13 +340,7 @@ void ZDLMainWindow::launch(){
 	proc->setWorkingDirectory(workingDirectory);
 
 	proc->setProcessChannelMode(QProcess::ForwardedChannels);
-
-	if (zconf->hasValue("zdl.general", "autoclose")) {
-		proc->startDetached(exec, args);
-	} else {
-		proc->start(exec, args);
-	}
-
+	proc->startDetached(exec, args);
 	procerr = proc->error();
 #endif
 	int stat;


### PR DESCRIPTION
This gets #38 fixed by starting the QProcess detached if you have "Close on launch" checked. It also continues #36 by removing the now-unneeded network support from the build system.

"Close on Launch" is extremely useful for me, as I launch ZDL from Steam and I use a Steam Controller.