### PR TITLE
Fix removal of files from file list

### DIFF
--- a/ZDLFileList.cpp
+++ b/ZDLFileList.cpp
@@ -39,7 +39,8 @@ void ZDLFileList::newConfig(){
 	auto zconf = ZDLConfigurationManager::getActiveConfiguration();
 	for (int i = 0; ; i++)
 	{
-		QString key{"zdl.save/file" + QString::number(i)};
+		QString key("zdl.save/file%1");
+		key = key.arg(i);
 		if (!zconf->contains(key))
 		{
 			break;
@@ -54,7 +55,8 @@ void ZDLFileList::rebuild(){
 	auto zconf = ZDLConfigurationManager::getActiveConfiguration();
 	for (int i = 0; ; i++)
 	{
-		QString key{"zdl.save/file" + QString::number(i)};
+		QString key("zdl.save/file%1");
+		key = key.arg(i);
 		if (!zconf->contains(key))
 		{
 			break;
@@ -65,7 +67,7 @@ void ZDLFileList::rebuild(){
 	for(int i = 0; i < count(); i++){
 		QListWidgetItem *itm = pList->item(i);
 		ZDLFileListable* fitm = (ZDLFileListable*)itm;
-		QString name = QString("file").append(QString::number(i));
+		QString name = QString("file%1").arg(QString::number(i));
 		zconf->setValue("zdl.save/" + name, fitm->getFile());
 	}
 }

--- a/ZDLFileList.cpp
+++ b/ZDLFileList.cpp
@@ -54,8 +54,7 @@ void ZDLFileList::rebuild(){
 	auto zconf = ZDLConfigurationManager::getActiveConfiguration();
 	for (int i = 0; ; i++)
 	{
-
-		QString key{"zdl.save/file%1" + QString::number(i)};
+		QString key{"zdl.save/file" + QString::number(i)};
 		if (!zconf->contains(key))
 		{
 			break;

--- a/ZDLFilePane.cpp
+++ b/ZDLFilePane.cpp
@@ -19,7 +19,7 @@
 #include <QtWidgets>
 #include <QApplication>
 #include <QListWidget>
-#include <iostream>
+//#include <iostream>
 
 #include "ZDLListWidget.h"
 #include "ZDLFilePane.h"
@@ -41,4 +41,5 @@ ZDLFilePane::ZDLFilePane(QWidget *parent):ZDLWidget(parent){
 
 void ZDLFilePane::rebuild(){
 	//std::cout << "Rebuilding config" << std::endl;
+    fList->rebuild();
 }


### PR DESCRIPTION
The configuration key was not being constructed properly, so it would end up looking for configuration keys like "zdl.save/file%10" instead of "zdl.save/file0".
Also, implement ZDLFilePane::rebuild()