### PR TITLE
Runs portably if qZDL.ini (not zdl.ini) is in executable directory.

### DIFF
--- a/qzdl.cpp
+++ b/qzdl.cpp
@@ -62,7 +62,7 @@ int main( int argc, char **argv ){
 
 	auto iniFormat = QSettings::registerFormat("ini", readZDLConf, writeZDLConf);
 	QSettings *tconf{nullptr};
-	auto portaConf = QCoreApplication::applicationDirPath() + "/zdl.ini";
+	auto portaConf = QCoreApplication::applicationDirPath() + "/qZDL.ini";
 	if (QFileInfo(portaConf).isFile())
 	{
 		tconf = new QSettings(portaConf, iniFormat);


### PR DESCRIPTION
This should take care of https://github.com/qbasicer/qzdl/issues/59

It currently runs portably if a file named zdl.ini is in the executable directory.

This changes it to run portably if a file named qZDL.ini (which is the current name of the file) is in the executable directory.