### PR TITLE
Modernize the build system even more

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ tags
 GPATH
 GTAGS
 GRTAGS
+.vscode

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,30 +1,10 @@
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.10)
+
+set(CMAKE_INCLUDE_CURRENT_DIR ON)
+set(CMAKE_AUTOMOC ON)
+
 project(qzdl LANGUAGES C CXX)
 find_package(Qt5 COMPONENTS Core Widgets REQUIRED)
-
-qt_wrap_cpp(
-	zdl
-	ZDL_MOC_OUTFILES
-	${PROJECT_SOURCE_DIR}/ZDLAboutDialog.h
-	${PROJECT_SOURCE_DIR}/ZDLAdvancedMultiplayerDialog.h
-	${PROJECT_SOURCE_DIR}/ZDLDMFlagCheckbox.h
-	${PROJECT_SOURCE_DIR}/ZDLDMFlagManager.h
-	${PROJECT_SOURCE_DIR}/ZDLDMFlagManager.h
-	${PROJECT_SOURCE_DIR}/ZDLFilePane.h
-	${PROJECT_SOURCE_DIR}/ZDLInfoBar.h
-	${PROJECT_SOURCE_DIR}/ZDLInterface.h
-	${PROJECT_SOURCE_DIR}/ZDLListWidget.h
-	${PROJECT_SOURCE_DIR}/ZDLListable.h
-	${PROJECT_SOURCE_DIR}/ZDLMainWindow.h
-	${PROJECT_SOURCE_DIR}/ZDLMultiPane.h
-	${PROJECT_SOURCE_DIR}/ZDLNameInput.h
-	${PROJECT_SOURCE_DIR}/ZDLNameListable.h
-	${PROJECT_SOURCE_DIR}/ZDLQSplitter.h
-	${PROJECT_SOURCE_DIR}/ZDLSettingsPane.h
-	${PROJECT_SOURCE_DIR}/ZDLSettingsTab.h
-	${PROJECT_SOURCE_DIR}/ZDLWidget.h
-	${PROJECT_SOURCE_DIR}/ZDMFlagPicker.h
-)
 
 add_executable(
 	zdl
@@ -53,12 +33,10 @@ add_executable(
 	ZDMFlagPicker.cpp
 	libwad.cpp
 	qzdl.cpp
-	${ZDL_MOC_OUTFILES}
 	${PROJECT_SOURCE_DIR}/zdlconf/zdlconf.cpp
 	${PROJECT_SOURCE_DIR}/zdlconf/inih-r44/ini.c
 )
 
-target_include_directories(zdl PRIVATE ${PROJECT_SOURCE_DIR})
 target_include_directories(zdl PRIVATE ${PROJECT_SOURCE_DIR}/zdlconf)
 target_include_directories(zdl PRIVATE ${PROJECT_SOURCE_DIR}/zdlconf/inih-r44)
 target_link_libraries(zdl Qt5::Core Qt5::Widgets)

--- a/ZDLSettingsTab.h
+++ b/ZDLSettingsTab.h
@@ -1,3 +1,6 @@
+#ifndef ZDLSETTINGSTAB_H
+#define ZDLSETTINGSTAB_H
+
 /*
  * This file is part of qZDL
  * Copyright (C) 2007-2010  Cody Harris
@@ -49,3 +52,5 @@ private:
 	QCheckBox *launchZDL;
 	QCheckBox *savePaths;
 };
+
+#endif


### PR DESCRIPTION
Modernize the build system even more, replacing the long-deprecated qt_wrap_cpp with CMAKE_AUOMOC.

Also adds include-guards to ZDLSettingsTab.h, which we all somehow forgot to do before :)