### PR TITLE
Tokenize extraArgs and alwaysAdd for the QProcess

### DIFF
--- a/ZDLMainWindow.h
+++ b/ZDLMainWindow.h
@@ -29,7 +29,7 @@
 class ZDLMainWindow: public QMainWindow{
     Q_OBJECT
 public:
-	ZDLMainWindow( QWidget *parent=0);
+    ZDLMainWindow(QWidget *parent=0);
 	~ZDLMainWindow();
 	void startRead();
 	void writeConfig();
@@ -49,4 +49,8 @@ protected:
 
     void badLaunch(QProcess::ProcessError);
 };
+
+
+QStringList parseExtraArgs(QString);
+
 #endif


### PR DESCRIPTION
This should finally fix (the most prominent of) the longstanding issues with "-extraArgs" and "alwaysAdd", in particular their handling of quote substrings in particular. It uses a stack-based tokenizer to tokenize the strings; '-f "a b"' gets tokenized as ["-f", "a b"]. As a result, it should fix https://github.com/qbasicer/qzdl/issues/33

Previous attempts were https://github.com/qbasicer/qzdl/pull/49 and https://github.com/qbasicer/qzdl/pull/55