### PR TITLE
Fix for typo which made "-deathmatch" argument not work

### DIFF
--- a/ZDLMainWindow.cpp
+++ b/ZDLMainWindow.cpp
@@ -320,7 +320,7 @@ QStringList ZDLMainWindow::getArguments(){
 		QString tGameType = zconf->value("zdl.save/gametype").toString();
 		if(tGameType != "0"){
 			if (tGameType == "2"){
-				ourString << "-deathmath";
+				ourString << "-deathmatch";
 			}
 			int players = 0;
 			if(zconf->contains("zdl.save/players")){


### PR DESCRIPTION
Deathmath sounds like a really cool game mode, but alas, it's not a valid command line argument for ZDoom. 