### PR TITLE
Fix overwriting .zdl files

### DIFF
--- a/ZDLInterface.cpp
+++ b/ZDLInterface.cpp
@@ -257,6 +257,7 @@ void ZDLInterface::saveZdlFile(){
 		auto current = ZDLConfigurationManager::getActiveConfiguration();
 		auto iniFormat = QSettings::registerFormat("ini", readZDLConf, writeZDLConf);
 		QSettings copy(fileName, iniFormat);
+		copy.clear(); // Otherwise, extra files will be in the overwritten zdl
 		current->beginGroup("zdl.save");
 		for (auto key: current->childKeys())
 		{


### PR DESCRIPTION
The QSettings constructor, which takes a filename and file format, loads the file if it exists, or creates it if it doesn't.

This caused extra files to be in the overwritten .zdl file, so when someone loaded it, the extra files would be in the file/mod list. This PR should fix that.