### PR TITLE
Qt 6 support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,8 @@ set(CMAKE_INCLUDE_CURRENT_DIR ON)
 set(CMAKE_AUTOMOC ON)
 
 project(qzdl LANGUAGES C CXX)
-find_package(Qt5 COMPONENTS Core Widgets REQUIRED)
+find_package(QT NAMES Qt6 Qt5 REQUIRED COMPONENTS Core Widgets)
+find_package(Qt${QT_VERSION_MAJOR} REQUIRED COMPONENTS Core Widgets REQUIRED)
 
 include(FetchContent)
 FetchContent_Declare(
@@ -50,4 +51,4 @@ add_executable(
 
 target_include_directories(zdl PRIVATE ${PROJECT_SOURCE_DIR}/zdlconf)
 target_include_directories(zdl PRIVATE ${inih_SOURCE_DIR})
-target_link_libraries(zdl Qt5::Core Qt5::Widgets)
+target_link_libraries(zdl Qt${QT_VERSION_MAJOR}::Core Qt${QT_VERSION_MAJOR}::Widgets)

--- a/qzdl.cpp
+++ b/qzdl.cpp
@@ -41,7 +41,9 @@ int main(int argc, char **argv)
 		args << QString(argv[i]);
 	}
 
+#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
 	QCoreApplication::setAttribute(Qt::AA_EnableHighDpiScaling);
+#endif
 
 	QApplication a(argc, argv);
 	qapp = &a;

--- a/qzdl.cpp
+++ b/qzdl.cpp
@@ -32,28 +32,28 @@ QApplication *qapp;
 QString versionString;
 ZDLMainWindow *mw;
 
-
-int main( int argc, char **argv ){
+int main(int argc, char **argv)
+{
 
 	QStringList args;
-	for(int i = 1; i < argc; i++){
+	for (int i = 1; i < argc; i++)
+	{
 		args << QString(argv[i]);
 	}
 
 	QCoreApplication::setAttribute(Qt::AA_EnableHighDpiScaling);
 
-	QApplication a( argc, argv );
+	QApplication a(argc, argv);
 	qapp = &a;
 
-
 #if defined(Q_WS_WIN)
-	versionString = ZDL_VERSION_STRING + QString(" (windows/") + QString(ZDL_BUILD)+QString(")");
+	versionString = ZDL_VERSION_STRING + QString(" (windows/") + QString(ZDL_BUILD) + QString(")");
 #elif defined(Q_WS_MAC)
-	versionString = ZDL_VERSION_STRING + QString(" (mac/") + QString(ZDL_BUILD)+QString(")");
+	versionString = ZDL_VERSION_STRING + QString(" (mac/") + QString(ZDL_BUILD) + QString(")");
 #elif defined(Q_WS_X11)
-	versionString = ZDL_VERSION_STRING + QString(" (linux/") + QString(ZDL_BUILD)+QString(")");
+	versionString = ZDL_VERSION_STRING + QString(" (linux/") + QString(ZDL_BUILD) + QString(")");
 #else
-	versionString = ZDL_VERSION_STRING + QString(" (other/") + QString(ZDL_BUILD)+QString(")");
+	versionString = ZDL_VERSION_STRING + QString(" (other/") + QString(ZDL_BUILD) + QString(")");
 #endif
 
 	QCoreApplication::setApplicationName("qZDL");
@@ -91,7 +91,7 @@ int main( int argc, char **argv ){
 			tconf->remove("");
 			QSettings zdlFile(zdlInfo.absoluteFilePath(), iniFormat);
 			zdlFile.beginGroup("zdl.save");
-			for (auto key: zdlFile.allKeys())
+			for (auto key : zdlFile.allKeys())
 			{
 				tconf->setValue(key, zdlFile.value(key));
 			}
@@ -108,12 +108,16 @@ int main( int argc, char **argv ){
 	QObject::connect(&a, &QApplication::lastWindowClosed, &a, &QApplication::quit);
 	mw->startRead();
 
-	if(hasZDLFile){
+	if (hasZDLFile)
+	{
 		//  A .zdl file as passed as a command line option
-		if(tconf->contains("zdl.general/zdllaunch")){
+		if (tconf->contains("zdl.general/zdllaunch"))
+		{
 			QString rc = tconf->value("zdl.general/zdllaunch").toString();
-			if(rc.length() > 0){
-				if(rc.compare("1") == 0){
+			if (rc.length() > 0)
+			{
+				if (rc.compare("1") == 0)
+				{
 					// Launching configuration NOW
 					mw->launch();
 					// ZDL QUIT
@@ -124,27 +128,32 @@ int main( int argc, char **argv ){
 	}
 
 	int ret = a.exec();
-	if (ret != 0){
+	if (ret != 0)
+	{
 		// ZDL QUIT, ERROR CONDITION
 		return ret;
 	}
-
 
 	mw->writeConfig();
 
 	delete mw;
 
 	bool doSave = true;
-	if (tconf->contains("zdl.general/rememberFilelist")){
+	if (tconf->contains("zdl.general/rememberFilelist"))
+	{
 		QString val = tconf->value("zdl.general/rememberFilelist").toString();
-		if (val == "0"){
+		if (val == "0")
+		{
 			doSave = false;
-		} else {
+		}
+		else
+		{
 			doSave = true;
 		}
 	}
-	if (!doSave){
-		for (int i = 0; ; i++)
+	if (!doSave)
+	{
+		for (int i = 0;; i++)
 		{
 			auto key = QString("zdl.save/file%1").arg(i);
 			if (!tconf->contains(key))
@@ -158,4 +167,3 @@ int main( int argc, char **argv ){
 	delete tconf;
 	return ret;
 }
-


### PR DESCRIPTION
Closes #91 

Implementation is boilerplate from here:

https://doc.qt.io/qt-6/cmake-qt5-and-qt6-compatibility.html

I've tested it as far as doing a Qt 6 build and launching it. It should keep the work that @Talon1024 did in https://github.com/qbasicer/qzdl/pull/80 to support legacy Qt versions.

I know I can merge this myself, but I'm going to let it it for a week or two before doing so.